### PR TITLE
Breaking change: chatper sorting, paginations, restore scroll, preserve list state on back, fix manhwa synonyms search

### DIFF
--- a/api/src/routes/manga.ts
+++ b/api/src/routes/manga.ts
@@ -39,6 +39,7 @@ const errorResponse = {
 
 const searchSchema = z.object({
   query: z.string().min(1),
+  page: z.coerce.number().int().positive().optional(),
   source: z.enum(['anilist', 'asura', 'both']).optional(),
   format: z.string().optional(),
   status: z.string().optional(),
@@ -240,7 +241,7 @@ const searchRoute = createRoute({
 });
 
 manga.openapi(searchRoute, (c) => {
-  const { query, source, format, status, genre, country, sort } = c.req.valid('query');
+  const { query, page, source, format, status, genre, country, sort } = c.req.valid('query');
   return service
     .search(query, (source || 'anilist') as MangaSource, {
       sort: normalizeSort(sort),
@@ -248,7 +249,7 @@ manga.openapi(searchRoute, (c) => {
       status: normalizeStatus(status),
       genre: genre && genre !== 'All' ? genre : undefined,
       country: normalizeCountry(country),
-    })
+    }, page || 1)
     .then((results) => jsonSuccess(c, results))
     .catch((error) =>
       jsonError(

--- a/api/src/services/manga-service.ts
+++ b/api/src/services/manga-service.ts
@@ -13,15 +13,16 @@ export class MangaService {
     query: string,
     source: MangaSource = 'anilist',
     filters?: { sort?: string[]; format?: string; status?: string; genre?: string; country?: string },
+    page = 1,
   ) {
     if (source === 'asura') {
-      return this.scraper.search(query);
+      return this.scraper.search(query, page);
     }
 
     if (source === 'both') {
       const [anilist, provider] = await Promise.all([
-        this.anilist.searchMangaWithFilters(query, 1, filters || {}),
-        this.scraper.search(query).catch(() => null),
+        this.anilist.searchMangaWithFilters(query, page, filters || {}),
+        this.scraper.search(query, page).catch(() => null),
       ]);
 
       return {
@@ -30,7 +31,7 @@ export class MangaService {
       };
     }
 
-    return this.anilist.searchMangaWithFilters(query, 1, filters || {});
+    return this.anilist.searchMangaWithFilters(query, page, filters || {});
   }
 
   async getMangaDetails(anilistId: number) {

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -340,7 +340,6 @@ const AppContent: React.FC = () => {
       saveNavState(nextState);
       setCurrentView(nextState.view);
       setViewData(nextState.data ?? null);
-      window.scrollTo(0, 0);
     };
 
     window.addEventListener('popstate', handlePopState);

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -754,10 +754,11 @@ const AppContent: React.FC = () => {
           )}
 
           {currentView === 'details' && (
-            <PageTransition key="details">
-              <Details 
-                seriesId={viewData} 
-                onNavigate={navigate} 
+            <PageTransition key={`details-${viewData ?? 'empty'}`}>
+              <Details
+                key={viewData ?? 'details'}
+                seriesId={viewData}
+                onNavigate={navigate}
                 onBack={handleBack}
                 user={user}
               />

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -51,8 +51,20 @@ const DEFAULT_FILTERS: FilterState = {
   status: 'All',
   genre: 'All',
   country: 'All',
-  sort: 'Popularity'
+  sort: 'Popularity',
 };
+
+const SORT_OPTIONS_ANILIST = [
+  'Popularity',
+  'Title',
+  'Score',
+  'Progress',
+  'Last Updated',
+  'Last Added',
+  'Start Date',
+];
+
+const SORT_OPTIONS_PROVIDER = ['Relevance', 'Chapters (High)', 'Chapters (Low)', 'Title'];
 
 const AVAILABLE_GENRES = [
   'Action', 'Adventure', 'Comedy', 'Drama', 'Ecchi', 'Fantasy', 'Horror', 'Mahou Shoujo', 'Mecha', 'Music', 'Mystery', 'Psychological', 'Romance', 'Sci-Fi', 'Slice of Life', 'Sports', 'Supernatural', 'Thriller'
@@ -241,12 +253,13 @@ const AppContent: React.FC = () => {
   };
 
   // Check if filters are active (dirty)
+  const defaultSort = searchSource === 'AsuraScans' ? 'Relevance' : 'Popularity';
   const isFiltersDirty = 
     filters.format !== 'All' || 
     filters.status !== 'All' || 
     filters.genre !== 'All' || 
     filters.country !== 'All' || 
-    filters.sort !== 'Popularity';
+    filters.sort !== defaultSort;
 
   // Load User Function (Extracted for re-use)
   const loadUser = async () => {
@@ -414,8 +427,16 @@ const AppContent: React.FC = () => {
     // setShowFilters(true);
   };
 
+  useEffect(() => {
+    const options = searchSource === 'AsuraScans' ? SORT_OPTIONS_PROVIDER : SORT_OPTIONS_ANILIST;
+    setFilters((prev) => {
+      if (options.includes(prev.sort)) return prev;
+      return { ...prev, sort: options[0] };
+    });
+  }, [searchSource]);
+
   const clearFilters = () => {
-    setFilters(DEFAULT_FILTERS);
+    setFilters({ ...DEFAULT_FILTERS, sort: defaultSort });
     setSearchQuery('');
     setShowFilters(false);
   };
@@ -743,6 +764,8 @@ const AppContent: React.FC = () => {
                        filters={filters}
                        onChange={setFilters}
                        availableGenres={AVAILABLE_GENRES}
+                       sortOptions={searchSource === 'AsuraScans' ? SORT_OPTIONS_PROVIDER : SORT_OPTIONS_ANILIST}
+                       defaultSort={defaultSort}
                      />
                    </div>
                 </motion.div>

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -43,6 +43,8 @@ type NavOptions = {
 };
 
 const NAV_STATE_KEY = 'manverse_nav_state_v1';
+const HOME_STATE_KEY = 'manverse_home_state_v2';
+const RECOMMEND_STATE_KEY = 'manverse_recommendations_state_v1';
 
 const DEFAULT_FILTERS: FilterState = {
   format: 'All',
@@ -80,6 +82,35 @@ const AppContent: React.FC = () => {
   // Animation State
   const [isFilterPanelOpen, setIsFilterPanelOpen] = useState(false);
   const historyIndexRef = useRef(0);
+
+  const persistScrollForView = (view: View) => {
+    if (typeof window === 'undefined') return;
+    if (view === 'home') {
+      try {
+        const raw = sessionStorage.getItem(HOME_STATE_KEY);
+        if (!raw) return;
+        const saved = JSON.parse(raw);
+        const scrollY = window.scrollY;
+        saved.scrollY = scrollY;
+        saved.searchScrollY = scrollY;
+        sessionStorage.setItem(HOME_STATE_KEY, JSON.stringify(saved));
+      } catch {
+        // Ignore storage errors
+      }
+      return;
+    }
+    if (view === 'recommendations') {
+      try {
+        const raw = sessionStorage.getItem(RECOMMEND_STATE_KEY);
+        if (!raw) return;
+        const saved = JSON.parse(raw);
+        saved.scrollY = window.scrollY;
+        sessionStorage.setItem(RECOMMEND_STATE_KEY, JSON.stringify(saved));
+      } catch {
+        // Ignore storage errors
+      }
+    }
+  };
 
   const loadStoredNavState = () => {
     if (typeof window === 'undefined') return null;
@@ -289,6 +320,7 @@ const AppContent: React.FC = () => {
       window.scrollTo(0, 0);
       return;
     }
+    persistScrollForView(currentView);
     window.scrollTo(0, 0);
     const nextIndex = options.replace ? historyIndexRef.current : historyIndexRef.current + 1;
     const state: NavState = {

--- a/app/components/SearchFilters.tsx
+++ b/app/components/SearchFilters.tsx
@@ -14,6 +14,8 @@ interface SearchFiltersProps {
   filters: FilterState;
   onChange: (filters: FilterState) => void;
   availableGenres: string[];
+  sortOptions?: string[];
+  defaultSort?: string;
   layout?: 'row' | 'column';
 }
 
@@ -21,9 +23,21 @@ const SearchFilters: React.FC<SearchFiltersProps> = ({
   filters, 
   onChange, 
   availableGenres,
+  sortOptions,
+  defaultSort,
   layout = 'row' 
 }) => {
   const [activeDropdown, setActiveDropdown] = useState<string | null>(null);
+  const resolvedSortOptions = sortOptions ?? [
+    'Popularity',
+    'Title',
+    'Score',
+    'Progress',
+    'Last Updated',
+    'Last Added',
+    'Start Date',
+  ];
+  const resolvedDefaultSort = defaultSort ?? resolvedSortOptions[0] ?? 'Popularity';
 
   // Close dropdowns when clicking outside
   const containerRef = useRef<HTMLDivElement>(null);
@@ -48,7 +62,7 @@ const SearchFilters: React.FC<SearchFiltersProps> = ({
       status: 'All',
       genre: 'All',
       country: 'All',
-      sort: 'Popularity'
+      sort: resolvedDefaultSort,
     });
   };
 
@@ -56,23 +70,34 @@ const SearchFilters: React.FC<SearchFiltersProps> = ({
     label, 
     filterKey, 
     options, 
-    value 
+    value,
+    defaultValue = 'All',
+    icon,
+    highlight = false,
   }: { 
     label: string, 
     filterKey: keyof FilterState, 
     options: string[], 
-    value: string 
+    value: string,
+    defaultValue?: string,
+    icon?: React.ReactNode,
+    highlight?: boolean,
   }) => (
     <div className="relative group min-w-[140px] flex-1">
-      <label className="text-[10px] font-bold text-gray-500 uppercase tracking-wider mb-1.5 block ml-1">{label}</label>
+      <label className="text-[10px] font-bold text-gray-500 uppercase tracking-wider mb-1.5 block ml-1 flex items-center gap-1.5">
+        {icon && <span className="text-primary/80">{icon}</span>}
+        {label}
+      </label>
       <button
         onClick={() => setActiveDropdown(activeDropdown === filterKey ? null : filterKey)}
         className={`w-full flex items-center justify-between px-3 py-2.5 bg-[#1a1a1a] border rounded-lg transition-all ${
           activeDropdown === filterKey 
             ? 'border-primary text-white ring-1 ring-primary/20' 
-            : value !== 'All' && value !== 'Popularity' && value !== 'Last Updated'
-              ? 'border-gray-600 text-white' 
-              : 'border-[#333] text-gray-400 hover:border-gray-500 hover:text-gray-200'
+            : value !== defaultValue
+              ? 'border-gray-600 text-white'
+              : highlight
+                ? 'border-primary/40 text-white hover:border-primary/70'
+                : 'border-[#333] text-gray-400 hover:border-gray-500 hover:text-gray-200'
         }`}
       >
         <span className="text-sm font-medium truncate pr-2">{value}</span>
@@ -123,10 +148,19 @@ const SearchFilters: React.FC<SearchFiltersProps> = ({
       
       {/* Filters Container */}
       <div className={
-        layout === 'row' 
+         layout === 'row' 
           ? "flex-1 grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4 w-full"
           : "flex flex-col gap-4 w-full"
       }>
+         <FilterDropdown 
+            label="Sort" 
+            filterKey="sort" 
+            value={filters.sort} 
+            options={resolvedSortOptions} 
+            defaultValue={resolvedDefaultSort}
+            icon={<SortIcon className="w-3.5 h-3.5" />}
+            highlight={true}
+         />
          <FilterDropdown 
             label="Genres" 
             filterKey="genre" 
@@ -150,12 +184,6 @@ const SearchFilters: React.FC<SearchFiltersProps> = ({
             filterKey="country" 
             value={filters.country} 
             options={['All', 'JP', 'KR', 'CN', 'TW']} 
-         />
-         <FilterDropdown 
-            label="Sort By" 
-            filterKey="sort" 
-            value={filters.sort} 
-            options={['Popularity', 'Title', 'Score', 'Progress', 'Last Updated', 'Last Added', 'Start Date']} 
          />
       </div>
 

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -61,8 +61,22 @@ const MAX_PROVIDER_SEARCH_CACHE = 40;
 const PROVIDER_SEARCH_TTL_MS = 10 * 60 * 1000;
 const providerDetailsCache = new Map<string, SeriesDetails>();
 const mappedProviderCache = new Map<string, SeriesDetails>();
-const providerSearchCache = new Map<string, { results: Series[]; expiresAt: number }>();
+type ProviderSearchCacheEntry = {
+  results: Series[];
+  expiresAt: number;
+  hasNextPage?: boolean;
+  currentPage?: number;
+};
+
+type ProviderSearchMeta = {
+  results: Series[];
+  hasNextPage: boolean;
+  currentPage: number;
+};
+
+const providerSearchCache = new Map<string, ProviderSearchCacheEntry>();
 const providerSearchInFlight = new Map<string, Promise<Series[]>>();
+const providerSearchMetaInFlight = new Map<string, Promise<ProviderSearchMeta>>();
 
 function loadCacheFromSession(key: string) {
   if (typeof window === 'undefined') return {};
@@ -89,9 +103,7 @@ function loadSearchCacheFromSession() {
   if (typeof window === 'undefined') return {};
   try {
     const raw = sessionStorage.getItem(PROVIDER_SEARCH_CACHE_KEY);
-    return raw
-      ? (JSON.parse(raw) as Record<string, { results: Series[]; expiresAt: number }>)
-      : {};
+    return raw ? (JSON.parse(raw) as Record<string, ProviderSearchCacheEntry>) : {};
   } catch {
     return {};
   }
@@ -254,13 +266,35 @@ function peekProviderSearchCache(query: string, provider: Source, page = 1) {
   if (!entry) return null;
   return {
     results: entry.results,
+    hasNextPage: entry.hasNextPage,
+    currentPage: entry.currentPage,
     stale: entry.expiresAt <= Date.now(),
     expiresAt: entry.expiresAt,
   };
 }
 
-function setCachedProviderSearch(key: string, results: Series[]) {
-  providerSearchCache.set(key, { results, expiresAt: Date.now() + PROVIDER_SEARCH_TTL_MS });
+function getCachedProviderSearchMeta(key: string): ProviderSearchMeta | null {
+  const entry = providerSearchCache.get(key);
+  if (!entry) return null;
+  if (entry.expiresAt <= Date.now()) return null;
+  return {
+    results: entry.results,
+    hasNextPage: entry.hasNextPage ?? entry.results.length > 0,
+    currentPage: entry.currentPage ?? 1,
+  };
+}
+
+function setCachedProviderSearch(
+  key: string,
+  results: Series[],
+  meta?: { hasNextPage?: boolean; currentPage?: number },
+) {
+  providerSearchCache.set(key, {
+    results,
+    expiresAt: Date.now() + PROVIDER_SEARCH_TTL_MS,
+    hasNextPage: meta?.hasNextPage,
+    currentPage: meta?.currentPage,
+  });
   persistSearchCacheToSession();
 }
 
@@ -304,7 +338,10 @@ export const api = {
     )
       .then((res) => {
         const results = res.results.map(formatSeriesResult);
-        setCachedProviderSearch(cacheKey, results);
+        setCachedProviderSearch(cacheKey, results, {
+          hasNextPage: res.hasNextPage,
+          currentPage: res.currentPage,
+        });
         return results;
       })
       .finally(() => {
@@ -332,7 +369,10 @@ export const api = {
     )
       .then((res) => {
         const results = res.results.map(formatSeriesResult);
-        setCachedProviderSearch(cacheKey, results);
+        setCachedProviderSearch(cacheKey, results, {
+          hasNextPage: res.hasNextPage,
+          currentPage: res.currentPage,
+        });
         return results;
       })
       .finally(() => {
@@ -343,6 +383,47 @@ export const api = {
   },
 
   peekProviderSearchCache,
+
+  searchProviderSeriesMeta: async (
+    query: string,
+    provider: Source = 'AsuraScans',
+    page = 1,
+  ): Promise<ProviderSearchMeta> => {
+    const trimmed = query.trim();
+    if (!trimmed) return { results: [], hasNextPage: false, currentPage: page };
+    const cacheKey = normalizeProviderSearchKey(provider, trimmed, page);
+    const cached = getCachedProviderSearchMeta(cacheKey);
+    if (cached) {
+      return cached;
+    }
+    const inFlight = providerSearchMetaInFlight.get(cacheKey);
+    if (inFlight) {
+      return inFlight;
+    }
+
+    const request = apiRequest<ProviderSearchResult>(
+      `/api/manga/search?source=asura&query=${encodeURIComponent(trimmed)}&page=${page}`,
+    )
+      .then((res) => {
+        const results = res.results.map(formatSeriesResult);
+        const payload = {
+          results,
+          hasNextPage: res.hasNextPage,
+          currentPage: res.currentPage,
+        };
+        setCachedProviderSearch(cacheKey, results, {
+          hasNextPage: res.hasNextPage,
+          currentPage: res.currentPage,
+        });
+        return payload;
+      })
+      .finally(() => {
+        providerSearchMetaInFlight.delete(cacheKey);
+      });
+
+    providerSearchMetaInFlight.set(cacheKey, request);
+    return request;
+  },
 
   prefetchProviderSearch: (queries: string[], provider: Source = 'AsuraScans') => {
     if (typeof window === 'undefined') return;

--- a/app/pages/Details.tsx
+++ b/app/pages/Details.tsx
@@ -416,6 +416,17 @@ const Details: React.FC<DetailsProps> = ({ seriesId, onNavigate, onBack, user })
     return asciiRatio * 0.6 + lengthScore * 0.35 + digitBoost;
   };
 
+  const expandSynonymTerms = (value: string) => {
+    const trimmed = value.trim();
+    if (!trimmed) return [];
+    const variants = new Set<string>([trimmed]);
+    const decomma = trimmed.replace(/[,:]/g, ' ').replace(/\s+/g, ' ').trim();
+    if (decomma && decomma !== trimmed) {
+      variants.add(decomma);
+    }
+    return Array.from(variants);
+  };
+
   const buildProviderSearchTerms = () => {
     if (!data) return [];
     const candidates = new Map<string, { term: string; score: number }>();
@@ -435,7 +446,9 @@ const Details: React.FC<DetailsProps> = ({ seriesId, onNavigate, onBack, user })
     push(data.title, 3.0);
     push(data.titles?.romaji, 2.6);
     push(data.titles?.native, 1.6);
-    (data.synonyms ?? []).forEach((synonym) => push(synonym, 3.4));
+    (data.synonyms ?? []).forEach((synonym) => {
+      expandSynonymTerms(synonym).forEach((term) => push(term, 3.4));
+    });
 
     return Array.from(candidates.values())
       .sort((a, b) => b.score - a.score)
@@ -2433,7 +2446,16 @@ const Details: React.FC<DetailsProps> = ({ seriesId, onNavigate, onBack, user })
                     {data.synonyms && data.synonyms.length > 0 && (
                       <div>
                         <span className="text-gray-500 uppercase tracking-wide text-[11px]">Synonyms</span>
-                        <div className="text-white font-semibold text-[14px]">{data.synonyms.join(', ')}</div>
+                        <div className="mt-2 flex flex-wrap gap-2">
+                          {data.synonyms.map((synonym, index) => (
+                            <span
+                              key={`${synonym}-${index}`}
+                              className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-semibold text-white/90"
+                            >
+                              {synonym}
+                            </span>
+                          ))}
+                        </div>
                       </div>
                     )}
                   </div>

--- a/app/pages/Home.tsx
+++ b/app/pages/Home.tsx
@@ -129,6 +129,13 @@ const Home: React.FC<HomeProps> = ({
 
       try {
         const saved = JSON.parse(raw);
+        const canRestoreSearch =
+          saved.searchContextKey === searchContextKey && Array.isArray(saved.searchResults);
+        const canRestoreDefault =
+          !isDiscoveryMode &&
+          (Array.isArray(saved.trending) ||
+            Array.isArray(saved.popular) ||
+            Array.isArray(saved.topRated));
         if (saved?.activeTab) {
           setActiveTab(saved.activeTab);
         }
@@ -141,7 +148,7 @@ const Home: React.FC<HomeProps> = ({
           tabPageCacheRef.current = saved.tabPageCache;
         }
 
-        if (saved.searchContextKey === searchContextKey && Array.isArray(saved.searchResults)) {
+        if (canRestoreSearch) {
           setSearchResults(saved.searchResults);
           setSearchPage(saved.searchPage || 1);
           setSearchHasMore(saved.searchHasMore ?? true);
@@ -160,6 +167,10 @@ const Home: React.FC<HomeProps> = ({
 
         if (!isDiscoveryMode && (!saved.trending || saved.trending.length === 0)) {
           await loadDefaultData();
+        }
+
+        if (canRestoreSearch || canRestoreDefault) {
+          setLoading(false);
         }
       } catch {
         if (!isDiscoveryMode) {

--- a/app/pages/Recommendations.tsx
+++ b/app/pages/Recommendations.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import { Series } from '../types';
 import { anilistApi } from '../lib/anilist';
 import SeriesCard from '../components/SeriesCard';
@@ -12,35 +12,145 @@ const Recommendations: React.FC<RecommendationsProps> = ({ onNavigate }) => {
   const [popular, setPopular] = useState<Series[]>([]);
   const [topRated, setTopRated] = useState<Series[]>([]);
   const [loading, setLoading] = useState(true);
+  const [pages, setPages] = useState({ trending: 1, popular: 1, topRated: 1 });
+  const [hasMore, setHasMore] = useState({ trending: true, popular: true, topRated: true });
+  const [loadingMore, setLoadingMore] = useState({ trending: false, popular: false, topRated: false });
+  const scrollYRef = useRef(0);
+  const RECOMMEND_STATE_KEY = 'manverse_recommendations_state_v1';
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const onScroll = () => {
+      scrollYRef.current = window.scrollY;
+    };
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
 
   useEffect(() => {
     const fetchData = async () => {
       setLoading(true);
       try {
         const [t, p, tr] = await Promise.all([
-          anilistApi.getTrending(),
-          anilistApi.getPopular(),
-          anilistApi.getTopRated()
+          anilistApi.getTrending(1),
+          anilistApi.getPopular(1),
+          anilistApi.getTopRated(1)
         ]);
         setTrending(t);
         setPopular(p);
         setTopRated(tr);
+        setPages({ trending: 1, popular: 1, topRated: 1 });
+        setHasMore({
+          trending: t.length > 0,
+          popular: p.length > 0,
+          topRated: tr.length > 0,
+        });
       } catch (e) {
         console.error(e);
       } finally {
         setLoading(false);
       }
     };
+    if (typeof window !== 'undefined') {
+      const raw = sessionStorage.getItem(RECOMMEND_STATE_KEY);
+      if (raw) {
+        try {
+          const saved = JSON.parse(raw);
+          const hasData =
+            (Array.isArray(saved.trending) && saved.trending.length > 0) ||
+            (Array.isArray(saved.popular) && saved.popular.length > 0) ||
+            (Array.isArray(saved.topRated) && saved.topRated.length > 0);
+          if (hasData) {
+            if (Array.isArray(saved.trending)) setTrending(saved.trending);
+            if (Array.isArray(saved.popular)) setPopular(saved.popular);
+            if (Array.isArray(saved.topRated)) setTopRated(saved.topRated);
+            if (saved.pages) setPages(saved.pages);
+            if (saved.hasMore) setHasMore(saved.hasMore);
+            if (typeof saved.scrollY === 'number') {
+              requestAnimationFrame(() => window.scrollTo(0, saved.scrollY));
+            }
+            setLoading(false);
+            return;
+          }
+        } catch {
+          // fall through to fetch
+        }
+      }
+    }
     fetchData();
   }, []);
 
-  const Section = ({ title, data }: { title: string, data: Series[] }) => (
+  const persistRecommendationsState = () => {
+    if (typeof window === 'undefined') return;
+    const payload = {
+      trending,
+      popular,
+      topRated,
+      pages,
+      hasMore,
+      scrollY: scrollYRef.current,
+    };
+    try {
+      sessionStorage.setItem(RECOMMEND_STATE_KEY, JSON.stringify(payload));
+    } catch {
+      // Ignore storage issues
+    }
+  };
+
+  useEffect(() => {
+    persistRecommendationsState();
+    return () => {
+      persistRecommendationsState();
+    };
+  }, [trending, popular, topRated, pages, hasMore]);
+
+  const handleLoadMore = async (section: 'trending' | 'popular' | 'topRated') => {
+    if (loadingMore[section] || !hasMore[section]) return;
+    const nextPage = pages[section] + 1;
+    setLoadingMore((prev) => ({ ...prev, [section]: true }));
+    try {
+      let data: Series[] = [];
+      if (section === 'trending') {
+        data = await anilistApi.getTrending(nextPage);
+        setTrending((prev) => [...prev, ...data]);
+      } else if (section === 'popular') {
+        data = await anilistApi.getPopular(nextPage);
+        setPopular((prev) => [...prev, ...data]);
+      } else {
+        data = await anilistApi.getTopRated(nextPage);
+        setTopRated((prev) => [...prev, ...data]);
+      }
+      setPages((prev) => ({ ...prev, [section]: nextPage }));
+      setHasMore((prev) => ({ ...prev, [section]: data.length > 0 }));
+    } finally {
+      setLoadingMore((prev) => ({ ...prev, [section]: false }));
+    }
+  };
+
+  const Section = ({
+    title,
+    data,
+    section,
+  }: {
+    title: string;
+    data: Series[];
+    section: 'trending' | 'popular' | 'topRated';
+  }) => (
     <div className="mb-12 animate-fade-in">
       <div className="flex items-center justify-between mb-6 px-4 md:px-0">
         <h2 className="text-2xl font-bold text-white flex items-center gap-3">
            <span className="w-1.5 h-6 bg-primary rounded-full"></span>
            {title}
         </h2>
+        {hasMore[section] && (
+          <button
+            onClick={() => handleLoadMore(section)}
+            disabled={loadingMore[section]}
+            className="text-xs font-semibold text-gray-300 px-3 py-1.5 rounded-full border border-white/10 hover:bg-white/5 disabled:opacity-60"
+          >
+            {loadingMore[section] ? 'Loading...' : 'Load more'}
+          </button>
+        )}
       </div>
       <div className="overflow-x-auto pb-8 -mx-4 px-4 md:mx-0 md:px-0 scrollbar-hide">
          <div className="flex gap-4 md:gap-6 w-max">
@@ -68,9 +178,9 @@ const Recommendations: React.FC<RecommendationsProps> = ({ onNavigate }) => {
           </div>
        ) : (
           <>
-            <Section title="Trending Now" data={trending} />
-            <Section title="All Time Popular" data={popular} />
-            <Section title="Top Rated" data={topRated} />
+            <Section title="Trending Now" data={trending} section="trending" />
+            <Section title="All Time Popular" data={popular} section="popular" />
+            <Section title="Top Rated" data={topRated} section="topRated" />
           </>
        )}
     </div>


### PR DESCRIPTION
fix(details): refresh provider search UX and reset state
feat(pagination): add list paging and view persistence
feat(pagination): add paged navigation and restore scroll
fix(navigation): preserve list state on back
fix(home): restore loading state on back
feat(pagination): add jump and first controls
fix(details): preserve synonym commas for search
fix(search): guard provider pagination
feat(search): add provider chapter sorting